### PR TITLE
Streamline canonicalization with Python implementation

### DIFF
--- a/didwebvh-resolver/src/crypto/mod.rs
+++ b/didwebvh-resolver/src/crypto/mod.rs
@@ -9,10 +9,10 @@
 use crate::error::{ResolverError, Result};
 use crate::types::{DIDLogEntry, Parameters};
 use base58::{self, ToBase58};
+use multihash::Multihash;
 use serde_json::{json, Value};
-use sha2::{Digest, Sha256};
-use multihash::{Multihash};
 use serde_json_canonicalizer::to_string as to_canonical_json;
+use sha2::{Digest, Sha256};
 
 /// SHA-256 multihash code
 pub const SHA2_256: u64 = 0x12;
@@ -21,17 +21,17 @@ pub const SHA2_256: u64 = 0x12;
 fn generate_multihash(data: &[u8]) -> Result<Vec<u8>> {
     // Create a new SHA-256 hasher
     let mut hasher = Sha256::new();
-    
+
     // Update the hasher with the input data
     hasher.update(data);
-    
+
     // Finalize and get the hash
     let hash = hasher.finalize();
-    
+
     // Wrap the hash in a multihash format
     let multihash = Multihash::<64>::wrap(SHA2_256, &hash)
         .map_err(|_| ResolverError::Verification("Failed to create multihash".to_string()))?;
-    
+
     Ok(multihash.to_bytes())
 }
 
@@ -58,33 +58,35 @@ pub fn verify_scid(entry: &DIDLogEntry) -> Result<()> {
 
     // 1. Create a copy of the entry to manipulate
     let mut entry_copy = entry.clone();
-    
+
     // 2. Remove the proof (not part of the SCID calculation)
-    entry_copy.proof.clear();
-    
+    entry_copy.proof = None;
+
     // 3. Replace the versionId with "{SCID}" placeholder
     entry_copy.version_id = "{SCID}".to_string();
-    
+
     // 4. Replace all instances of the actual SCID with the placeholder in the entire entry
     let entry_json = serde_json::to_string(&entry_copy).map_err(|e| {
-        ResolverError::Verification(format!("Failed to serialize entry for SCID verification: {}", e))
+        ResolverError::Verification(format!(
+            "Failed to serialize entry for SCID verification: {}",
+            e
+        ))
     })?;
-    
+
     let entry_with_placeholders = entry_json.replace(scid, "{SCID}");
-    
+
     // 5. Parse the modified entry back to a JSON value
     let entry_value: Value = serde_json::from_str(&entry_with_placeholders).map_err(|e| {
         ResolverError::Verification(format!("Failed to parse entry with placeholders: {}", e))
     })?;
-    
+
     // 6. Apply JCS to get a canonical representation
-    let canonical = to_canonical_json(&entry_value).map_err(|e| {
-        ResolverError::Verification(format!("Failed to canonicalize JSON: {}", e))
-    })?;
-    
+    let canonical = to_canonical_json(&entry_value)
+        .map_err(|e| ResolverError::Verification(format!("Failed to canonicalize JSON: {}", e)))?;
+
     // 7. Calculate the hash using SHA-256 (as specified for did:webvh 0.5)
     let calculated_scid = hash_to_base58btc(canonical.as_bytes())?;
-    
+
     // 8. Compare with the provided SCID
     if calculated_scid != *scid {
         return Err(ResolverError::Verification(format!(
@@ -92,7 +94,7 @@ pub fn verify_scid(entry: &DIDLogEntry) -> Result<()> {
             calculated_scid, scid
         )));
     }
-    
+
     Ok(())
 }
 
@@ -100,26 +102,24 @@ pub fn verify_scid(entry: &DIDLogEntry) -> Result<()> {
 ///
 /// The entry hash is generated as:
 /// base58btc(multihash(JCS(entry with versionId set to predecessor's versionId), <hash algorithm>))
-pub fn verify_entry_hash(
-    entry: &DIDLogEntry,
-    prev_version_id: Option<&str>
-) -> Result<()> {
+pub fn verify_entry_hash(entry: &DIDLogEntry, prev_version_id: Option<&str>) -> Result<()> {
     // Extract the version number and entry hash from the versionId
     let version_parts: Vec<&str> = entry.version_id.split('-').collect();
     if version_parts.len() != 2 {
         return Err(ResolverError::Verification(format!(
-            "Invalid versionId format: {}", entry.version_id
+            "Invalid versionId format: {}",
+            entry.version_id
         )));
     }
-    
+
     let entry_hash = version_parts[1];
-    
+
     // Create a copy of the entry to manipulate
     let mut entry_copy = entry.clone();
-    
+
     // Remove the proof (not part of the hash calculation)
-    entry_copy.proof.clear();
-    
+    entry_copy.proof = None;
+
     // Set the versionId to the predecessor's versionId
     // For the first entry, this is the SCID
     // For subsequent entries, this is the previous entry's versionId
@@ -128,24 +128,30 @@ pub fn verify_entry_hash(
         None => {
             // If no previous versionId is provided (for the first entry),
             // use the SCID from parameters
-            entry_copy.parameters.scid.as_ref().ok_or_else(|| {
-                ResolverError::Verification("Missing SCID for first entry hash verification".to_string())
-            })?.clone()
+            entry_copy
+                .parameters
+                .scid
+                .as_ref()
+                .ok_or_else(|| {
+                    ResolverError::Verification(
+                        "Missing SCID for first entry hash verification".to_string(),
+                    )
+                })?
+                .clone()
         }
     };
-    
+
     // Apply JCS to get a canonical representation
     let entry_json = serde_json::to_value(entry_copy).map_err(|e| {
         ResolverError::Verification(format!("Failed to convert entry to JSON: {}", e))
     })?;
-    
-    let canonical = to_canonical_json(&entry_json).map_err(|e| {
-        ResolverError::Verification(format!("Failed to canonicalize JSON: {}", e))
-    })?;
-    
+
+    let canonical = to_canonical_json(&entry_json)
+        .map_err(|e| ResolverError::Verification(format!("Failed to canonicalize JSON: {}", e)))?;
+
     // Calculate the hash using SHA-256 (as specified for did:webvh 0.5)
     let calculated_hash = hash_to_base58btc(canonical.as_bytes())?;
-    
+
     // Compare with the provided hash
     if calculated_hash != entry_hash {
         return Err(ResolverError::Verification(format!(
@@ -153,7 +159,7 @@ pub fn verify_entry_hash(
             calculated_hash, entry_hash
         )));
     }
-    
+
     Ok(())
 }
 
@@ -162,21 +168,21 @@ pub fn verify_did_log_integrity(entries: &[DIDLogEntry]) -> Result<()> {
     if entries.is_empty() {
         return Err(ResolverError::Verification("Empty DID log".to_string()));
     }
-    
+
     // Verify the SCID of the first entry
     verify_scid(&entries[0])?;
-    
+
     // Verify the entry hash of each entry
     for (i, entry) in entries.iter().enumerate() {
         let prev_version_id = if i == 0 {
             None // First entry uses SCID
         } else {
-            Some(entries[i-1].version_id.as_str())
+            Some(entries[i - 1].version_id.as_str())
         };
-        
+
         verify_entry_hash(entry, prev_version_id)?;
     }
-    
+
     Ok(())
 }
 
@@ -190,14 +196,11 @@ pub fn hash_multikey(multikey: &str) -> Result<String> {
 /// Verify pre-rotation key hashes
 ///
 /// Checks that each key in update_keys has its hash in the previous next_key_hashes array
-pub fn verify_prerotation(
-    update_keys: &[String],
-    prev_next_key_hashes: &[String]
-) -> Result<()> {
+pub fn verify_prerotation(update_keys: &[String], prev_next_key_hashes: &[String]) -> Result<()> {
     // For each update key, check if its hash is in the previous next_key_hashes
     for key in update_keys {
         let key_hash = hash_multikey(key)?;
-        
+
         if !prev_next_key_hashes.contains(&key_hash) {
             return Err(ResolverError::Verification(format!(
                 "Pre-rotation verification failed: hash of key {} not found in previous nextKeyHashes",
@@ -205,7 +208,7 @@ pub fn verify_prerotation(
             )));
         }
     }
-    
+
     Ok(())
 }
 
@@ -213,25 +216,25 @@ pub fn verify_prerotation(
 mod tests {
     use super::*;
     use crate::types::Proof;
-    
+
     #[test]
     fn test_hash_to_base58btc() {
         let data = b"test data";
         let hash = hash_to_base58btc(data).unwrap();
-        
+
         // The hash should be a non-empty string
         assert!(!hash.is_empty());
-        
+
         // The same data should always produce the same hash
         let hash2 = hash_to_base58btc(data).unwrap();
         assert_eq!(hash, hash2);
-        
+
         // Different data should produce different hashes
         let data2 = b"different data";
         let hash3 = hash_to_base58btc(data2).unwrap();
         assert_ne!(hash, hash3);
     }
-    
+
     #[test]
     fn test_verify_entry_hash_with_simple_data() {
         // Create a simple entry with a known hash
@@ -248,33 +251,37 @@ mod tests {
                 "@context": ["https://www.w3.org/ns/did/v1"],
                 "id": "did:webvh:QmfGEUAcMpzo25kF2Rhn8L5FAXysfGnkzjwdKoNPi615XQ:domain.example"
             }),
-            proof: vec![Proof {
+            proof: Some(vec![Proof {
                 type_: "DataIntegrityProof".to_string(),
                 cryptosuite: "eddsa-jcs-2022".to_string(),
                 verification_method: "did:key:z6MkhbNRN2Q9BaY9TvTc2K3izkhfVwgHiXL7VWZnTqxEvc3R#z6MkhbNRN2Q9BaY9TvTc2K3izkhfVwgHiXL7VWZnTqxEvc3R".to_string(),
                 created: "2024-09-26T23:22:26Z".to_string(),
                 proof_purpose: "assertionMethod".to_string(),
                 proof_value: "z2fPF6fMewtV15kji2N432R7RjmmFs8p7MiSHSTM9FoVmJPtc3JUuZ472pZKoWgZDuT75EDwkGmZbK8ZKVF55pXvx".to_string(),
-            }],
+            }]),
         };
-        
+
         // Calculate the hash for this entry manually to test
         let mut entry_copy = entry.clone();
-        entry_copy.proof.clear();
+        entry_copy.proof = None;
         entry_copy.version_id = "QmfGEUAcMpzo25kF2Rhn8L5FAXysfGnkzjwdKoNPi615XQ".to_string();
-        
+
         let entry_json = serde_json::to_value(entry_copy).unwrap();
         let canonical = to_canonical_json(&entry_json).unwrap();
         let calculated_hash = hash_to_base58btc(canonical.as_bytes()).unwrap();
-        
+
         // Update the entry to use our calculated hash
         entry.version_id = format!("1-{}", calculated_hash);
-        
+
         // Now verify it - this should pass
         let result = verify_entry_hash(&entry, None);
-        assert!(result.is_ok(), "Entry hash verification failed: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "Entry hash verification failed: {:?}",
+            result
+        );
     }
-    
+
     // Additional tests would be added for:
     // - SCID verification
     // - Multi-entry log integrity verification

--- a/didwebvh-resolver/src/log/mod.rs
+++ b/didwebvh-resolver/src/log/mod.rs
@@ -145,7 +145,7 @@ pub fn parse_did_log(log_bytes: &[u8], did: &str) -> Result<DIDLog> {
         if is_first_entry {
             verify_scid(&entry)
                 .map_err(|e| ResolverError::LogProcessing(
-                    format!("SCID verification failed at line {}: {}", line_idx + 1, e)
+                    format!("Log: SCID verification failed at line {}: {}", line_idx + 1, e)
                 ))?;
         }
         
@@ -231,7 +231,7 @@ fn validate_entry_structure(entry: &DIDLogEntry, entry_index: usize) -> Result<(
     }
     
     // Check that there is at least one proof
-    if entry.proof.is_empty() {
+    if entry.proof.is_none() {
         return Err(ResolverError::LogProcessing(
             "Missing proof".to_string()
         ));
@@ -506,14 +506,14 @@ mod tests {
                 "@context": ["https://www.w3.org/ns/did/v1"],
                 "id": "did:webvh:QmfGEUAcMpzo25kF2Rhn8L5FAXysfGnkzjwdKoNPi615XQ:example.com"
             }),
-            proof: vec![Proof {
+            proof: Some(vec![Proof {
                 type_: "DataIntegrityProof".to_string(),
                 cryptosuite: "eddsa-jcs-2022".to_string(),
                 verification_method: "did:key:z6MkhbNRN2Q9BaY9TvTc2K3izkhfVwgHiXL7VWZnTqxEvc3R#z6MkhbNRN2Q9BaY9TvTc2K3izkhfVwgHiXL7VWZnTqxEvc3R".to_string(),
                 created: "2024-09-26T23:22:26Z".to_string(),
                 proof_purpose: "assertionMethod".to_string(),
                 proof_value: "z2fPF6fMewtV15kji2N432R7RjmmFs8p7MiSHSTM9FoVmJPtc3JUuZ472pZKoWgZDuT75EDwkGmZbK8ZKVF55pXvx".to_string(),
-            }],
+            }]),
         };
         
         // Validate as the first entry (entry_index = 0)
@@ -540,14 +540,14 @@ mod tests {
                 "@context": ["https://www.w3.org/ns/did/v1"],
                 "id": "did:webvh:QmfGEUAcMpzo25kF2Rhn8L5FAXysfGnkzjwdKoNPi615XQ:example.com"
             }),
-            proof: vec![Proof {
+            proof: Some(vec![Proof {
                 type_: "DataIntegrityProof".to_string(),
                 cryptosuite: "eddsa-jcs-2022".to_string(),
                 verification_method: "did:key:z6MkhbNRN2Q9BaY9TvTc2K3izkhfVwgHiXL7VWZnTqxEvc3R#z6MkhbNRN2Q9BaY9TvTc2K3izkhfVwgHiXL7VWZnTqxEvc3R".to_string(),
                 created: "2024-09-26T23:22:26Z".to_string(),
                 proof_purpose: "assertionMethod".to_string(),
                 proof_value: "z2fPF6fMewtV15kji2N432R7RjmmFs8p7MiSHSTM9FoVmJPtc3JUuZ472pZKoWgZDuT75EDwkGmZbK8ZKVF55pXvx".to_string(),
-            }],
+            }]),
         };
         
         // Validate as the first entry (entry_index = 0)

--- a/didwebvh-resolver/src/types/mod.rs
+++ b/didwebvh-resolver/src/types/mod.rs
@@ -22,36 +22,45 @@ pub struct DIDLogEntry {
     pub state: Value,
     
     /// Data Integrity proofs
-    pub proof: Vec<Proof>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub proof: Option<Vec<Proof>>,
 }
 
 /// Parameters that control DID processing
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Parameters {
     /// Specification version (e.g., "did:webvh:0.5")
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub method: Option<String>,
     
     /// Self-certifying identifier
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub scid: Option<String>,
     
     /// Keys authorized for updates
     #[serde(rename = "updateKeys")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub update_keys: Option<Vec<String>>,
     
     /// Pre-rotation key hashes
     #[serde(rename = "nextKeyHashes")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub next_key_hashes: Option<Vec<String>>,
     
     /// DID portability flag
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub portable: Option<bool>,
     
     /// Witness configuration
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub witness: Option<WitnessConfig>,
     
     /// Deactivation status
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub deactivated: Option<bool>,
     
     /// Cache TTL in seconds
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ttl: Option<u64>,
 }
 
@@ -216,14 +225,14 @@ mod tests {
                 "@context": ["https://www.w3.org/ns/did/v1"],
                 "id": "did:webvh:QmfGEUAcMpzo25kF2Rhn8L5FAXysfGnkzjwdKoNPi615XQ:domain.example"
             }),
-            proof: vec![Proof {
+            proof: Some(vec![Proof {
                 type_: "DataIntegrityProof".to_string(),
                 cryptosuite: "eddsa-jcs-2022".to_string(),
                 verification_method: "did:key:z6MkhbNRN2Q9BaY9TvTc2K3izkhfVwgHiXL7VWZnTqxEvc3R#z6MkhbNRN2Q9BaY9TvTc2K3izkhfVwgHiXL7VWZnTqxEvc3R".to_string(),
                 created: "2024-09-26T23:22:26Z".to_string(),
                 proof_purpose: "assertionMethod".to_string(),
                 proof_value: "z2fPF6fMewtV15kji2N432R7RjmmFs8p7MiSHSTM9FoVmJPtc3JUuZ472pZKoWgZDuT75EDwkGmZbK8ZKVF55pXvx".to_string(),
-            }],
+            }]),
         };
 
         // Serialize to JSON
@@ -241,7 +250,7 @@ mod tests {
         assert_eq!(entry.parameters.next_key_hashes, deserialized.parameters.next_key_hashes);
         
         // Just check that we have the same number of proofs
-        assert_eq!(entry.proof.len(), deserialized.proof.len());
+        assert_eq!(entry.proof.unwrap().len(), deserialized.proof.unwrap().len());
         
         // More detailed checks could be added
     }
@@ -261,9 +270,10 @@ mod tests {
         assert_eq!(entry.parameters.scid, Some("QmfGEUAcMpzo25kF2Rhn8L5FAXysfGnkzjwdKoNPi615XQ".to_string()));
         
         // Check that the proof was deserialized correctly
-        assert_eq!(entry.proof.len(), 1);
-        assert_eq!(entry.proof[0].type_, "DataIntegrityProof");
-        assert_eq!(entry.proof[0].cryptosuite, "eddsa-jcs-2022");
-        assert_eq!(entry.proof[0].proof_purpose, "assertionMethod");
+        let proof = entry.proof.unwrap();
+        assert_eq!(proof.len(), 1);
+        assert_eq!(proof[0].type_, "DataIntegrityProof");
+        assert_eq!(proof[0].cryptosuite, "eddsa-jcs-2022");
+        assert_eq!(proof[0].proof_purpose, "assertionMethod");
     }
 }


### PR DESCRIPTION
Various properties were serialized with an explicit `null` in Rust, whereas the [Python implementation](https://github.com/decentralized-identity/didwebvh-py) left the properties out completely. A similar problem existed for arrays.
The Rust implementation serialized an empty array; the Python implementation left out the property.